### PR TITLE
Use fine grained timeouts when +reltime is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ arrow keys. Vim will show a message at the bottom of the window when you try to
 use your arrow keys.
 
 In order to see Dogmatic's output in Insert mode you will need to add this line to your vimrc.
+
     set cmdheight=2
 
-You can set a timeout value for Dogmatic so that it will only count the first arrow press in a sequence where you press multiple arrow keys
+You can set a timeout value (in milliseconds) for Dogmatic so that it will only count the first arrow press in a sequence where you press multiple arrow keys
 
-    :let g:dogmatic_timeout = 1   "one second timeout
+    :let g:dogmatic_timeout = 1000  "one second timeout
 
 or
 
-    :let g:dogmatic_timeout = 5   "five second timeout
+    :let g:dogmatic_timeout = 500   "half a second timeout
+
+Note that if Vim is not compiled with the `+reltime` feature, the minimum interval between key presses that Dogmatic can see is 1 second, meaning any value of `g:dogmatic_timeout` below 1000 will be regarded as 0.

--- a/plugin/dogmatic.vim
+++ b/plugin/dogmatic.vim
@@ -1,23 +1,36 @@
 "Dogmatic.vim disables your arrow keys and lets you know how many times you
 "have tried to use them.
 " Author:   Matt Margolis  @mrmargolis
-let s:presses = { 'left': 0, 'right': 0, 'up': 0, 'down': 0 }
-let s:last_arrow_press_time = 0
 
-"Override with a number of seconds if you want a timeout between
-"tracked arrow presses
-let g:dogmatic_timeout = 0
+let s:presses = { 'left': 0, 'right': 0, 'up': 0, 'down': 0 }
+let s:last_arrow_press_time = has('reltime') ? [0,0] : 0
+
+"Override with a number of milliseconds if you want a timeout between
+"tracked arrow presses.
+"Note that if vim is not compiled with +reltime support, there is a 1 second
+"resolution in the time difference calculation.
+if !exists('g:dogmatic_timeout')
+    let g:dogmatic_timeout = 0
+endif
 
 function! dogmatic#TrackArrowPress(key)
   if s:TimeSinceLastTrack() >= g:dogmatic_timeout
     let s:presses[a:key] += 1
-    let s:last_arrow_press_time = localtime()
     echomsg "Dogmatic.vim: You have tried to use the " . a:key . " arrow key " . s:presses[a:key] . " time(s) all keys: " . s:TotalArrowPresses() . " time(s)"
   endif
+  let s:last_arrow_press_time = has('reltime') ? reltime() : localtime()
 endfunction
 
 function! s:TimeSinceLastTrack()
-  return (localtime() - s:last_arrow_press_time)
+  if g:dogmatic_timeout == 0 " Don't spend any time here if no timeout is specified
+    return 0
+  endif
+  if has('reltime')
+    let [sec, usec] = map(split(reltimestr(reltime(s:last_arrow_press_time)), '\.'), 'str2nr(v:val)')
+    return sec*1000 + usec/1000
+  else
+    return (localtime() - s:last_arrow_press_time) * 1000
+  endif
 endfunction
 
 function! s:TotalArrowPresses()


### PR DESCRIPTION
If Vim is compiled with +reltime support, use the reltime() function to
calculate time intervals. Fall back to localtime() if +reltime is not
available.

The reltime function provides times in nanoseconds, but this changeset
adjusts them to milliseconds to make them consistent with other timeout
values used in some Vim's settings, e.g. timeoutlen. The variable
g:dogmatic_timeout is now expected to have a value in milliseconds.

The timeout logic is also changed so that every arrow key pressed will
update s:last_arrow_press_time, but only those outside the timeout
interval will trigger showing Dogmatic's report. This is done so that if
an arrow key is pressed and kept pressed, the counter only increases
once, and not again until an arrow key is pressed g:dogmatic_timeout
seconds after the last arrow key press. This avoids the counters to be
increased every g:dogmatic_timeout milliseconds when the key is left
pressed.

Reflect these changes in the README file.

Ref: issue #2
